### PR TITLE
ci: bump actions/checkout from 5 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Recreates Dependabot PR #32's one-line `actions/checkout` upgrade from the latest `main` branch.

## Why a replacement PR?

After Dependabot PR #31 updated `actions/setup-python`, #32 became conflicting because both PRs changed `.github/workflows/ci.yml` from the same base. GitHub reported the Dependabot branch as up-to-date but conflicting, so it could not be safely squash-merged.

This replacement contains the identical checkout `v5 → v7` update on a `feature/…` branch and is ready for a normal squash merge. Once this PR is merged, #32 can be closed as superseded.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pyright` — 0 errors
- `pytest` — 31 passed