### PR TITLE
release: prepare v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [4.0.0] - In development
+## [4.0.0] - 2026-08-09
 
 ### Added
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -5,7 +5,7 @@
 
 **以 Bybit V5 公開市場資料為基礎的規則式加密貨幣市場分析、訊號產生與 Discord 整合工具。**
 
-> **v4 正在開發中。**目前最新正式版為 v3.1；本分支在保留 repo、issues、外部貢獻、forks 與 Git history 的前提下進行現代化重構。
+> **目前正式版本：v4.0.0。**這個 major release 在保留 repo、issues、外部貢獻、forks 與 Git history 的前提下完成現代化重構；前一個 legacy release 為 v3.1。
 
 [English](README.md)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 **Rule-based cryptocurrency market analysis, signal generation, and Discord
 integration powered by public Bybit V5 market data.**
 
-> **v4 is in development.** The latest released legacy version is v3.1. This
-> branch modernizes the project without discarding its repository, issues,
-> merged contributions, or Git history.
+> **Current release: v4.0.0.** This major release modernizes the project
+> without discarding its repository, issues, merged contributions, or Git
+> history. The latest legacy release was v3.1.
 
 [繁體中文](README-zh.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.0.0a0"
+version = "4.0.0"
 description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.0.0a0"
+__version__ = "4.0.0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import bybit_predict
+
+
+def test_runtime_version_matches_package_metadata() -> None:
+    project_root = Path(__file__).parents[2]
+    with (project_root / "pyproject.toml").open("rb") as file:
+        metadata = tomllib.load(file)
+
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.0.0"


### PR DESCRIPTION
## Summary

Final release-preparation metadata for Bybit-Predict v4.0.0.

- Promotes package metadata from `4.0.0a0` to `4.0.0`.
- Synchronizes `bybit_predict.__version__` with the package version and adds a regression test to prevent drift.
- Dates the v4.0.0 changelog entry as `2026-08-09`.
- Updates English and Traditional Chinese README status from “v4 is in development” to “Current release: v4.0.0”.

## Validation

- Editable rebuild successfully produced and installed `bybit_predict-4.0.0`.
- Runtime version and installed package metadata both report `4.0.0`.
- `ruff check .`
- `ruff format --check .`
- `pyright` — 0 errors
- `pytest` — 32 passed

## Release sequence after merge

1. Confirm the main-branch CI run is green.
2. Create annotated tag `v4.0.0` at the merge commit.
3. Publish the GitHub v4.0.0 Release using the changelog summary.

This PR deliberately excludes #25 backtesting, which remains the planned v4.1.0 scope.