### PR TITLE
feat: add reproducible backtesting and evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to Bybit-Predict are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [4.1.0] - In development
+
+### Added
+
+- Reproducible historical backtesting with explicit UTC ranges, saved normalized
+  candle CSV input, declared execution assumptions, performance metrics, and
+  buy-and-hold plus SMA direction baselines.
+- Historical Bybit V5 candle pagination for date-range evaluation.
 
 ## [4.0.0] - 2026-08-09
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -28,6 +28,7 @@ Bybit-Predict 從 Bybit 取得 OHLCV K 線，產生供參考的市場訊號與�
 - 提供 CLI，以及可選用、非阻塞的 Discord slash command。
 - 透過 Bybit instrument metadata 驗證有效交易對，不再 hard-code 幣種清單。
 - 具備測試、Ruff、Pyright、GitHub Actions CI 與 Dependabot。
+- 提供可重現的歷史 backtesting：可保存 CSV 輸入、明確列出假設、計算績效指標，並與兩個簡單 baseline 比較（v4.1.0 開發中）。
 
 ## 系統需求
 
@@ -86,6 +87,38 @@ Reference levels:
 若 symbol、參數或市場資料有錯，CLI 會以非零 status code 結束。也可使用
 `python -m bybit_predict analyze BTCUSDT`。
 
+### 歷史 Backtest
+
+v4.1.0 開發分支加入可重現的 `backtest` command：策略只會看到先前的固定已收線
+K 線 window；非 neutral 訊號在下一根 K 線開盤模擬進場、同一根收盤模擬出場。輸出會
+連同假設、績效指標和 baseline 一起顯示，不是交易建議。
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --save-data data/btcusdt-2024-4h.csv
+```
+
+要離線重跑相同的 normalized CSV 資料：
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --data data/btcusdt-2024-4h.csv
+```
+
+`--start` 是包含起點、`--end` 是不包含終點；只輸入日期時代表 UTC 午夜。完整的
+metric 定義、baseline 語意、重現方式和重要限制請見
+[backtesting and evaluation](docs/backtesting.md)。
+
 ## Discord slash commands
 
 安裝 Discord optional dependency、建立 Discord application/bot，並以 `bot` 和
@@ -141,10 +174,15 @@ Bybit V5 public API
         │
 BybitV5MarketClient ──→ normalized UTC Candles
         │
-PredictionService ──→ LegacyRuleBasedStrategy ──→ PredictionResult
-        │                         │
-        ├──────── CLI             └── future strategies / v4.1 backtesting
-        └──────── Discord slash command
+        ├── PredictionService ──→ LegacyRuleBasedStrategy ──→ PredictionResult
+        │         │                         │
+        │         ├──────── CLI             └── future strategies
+        │         └──────── Discord slash command
+        │
+        └── BacktestEngine ─────→ LegacyRuleBasedStrategy ──→ BacktestResult
+                  │
+                  ├──────── historical CLI
+                  └──────── saved CSV input/output
 ```
 
 - `market/` 負責 Bybit V5 requests、retry 範圍、pagination 與 response normalization。
@@ -156,7 +194,7 @@ PredictionService ──→ LegacyRuleBasedStrategy ──→ PredictionResult
 
 `LegacyRuleBasedStrategy` 是刻意保留下來的歷史核心：它分類 K 線實體與影線、比較顯著多空量能，並從 IQR 和 percentile 算出選用的參考價位。明確命名策略後，未來新策略才能公平比較。v4 刻意修正 v3 的 zero/six-candle volume window、時間處理，以及 bearish Fibonacci label ordering；完整 compatibility baseline 與保留的語意請見 [legacy strategy migration notes](docs/legacy-strategy-changes.md)。
 
-預計在 **v4.1.0** 完成的 backtesting（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）會先定義 entry/exit semantics，再量測方向正確率、win rate、average return、maximum drawdown 與適當 baseline。在此之前，本專案不宣稱訊號具有任何已驗證的預測能力。
+**v4.1.0** 的 backtesting（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）先定義固定 trailing analysis window、下一根開盤進場、同根收盤出場，以及 neutral 訊號維持現金，再量測方向正確率、win rate、average return、maximum drawdown 與零 risk-free-rate Sharpe ratio；並與 buy-and-hold 和 10/20 SMA direction baseline 比較。確切規則與限制請見 [backtesting and evaluation](docs/backtesting.md)。在經過情境化的解讀前，本專案不宣稱訊號具有任何已驗證的預測能力。
 
 ## 開發與品質檢查
 
@@ -174,7 +212,7 @@ PR 會在 Python 3.11、3.12 與 3.13 執行上述檢查。請參閱
 ## Roadmap
 
 - **v4.0.0：**package 架構、公開 Bybit V5 client、stateless legacy strategy、CLI、Discord slash command、設定、品質 gate 與文件。
-- **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）。
+- **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)，開發中）。
 - **後續：**可在同一 strategy contract 下加入更多策略；ML 是未來可能方向，並非現有功能。
 
 ## 貢獻與歷史

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ outcome.
 - Active symbols validated using Bybit instrument metadata, not a hard-coded
   coin list.
 - Tests, Ruff, Pyright, GitHub Actions CI, and Dependabot.
+- Deterministic historical backtesting with saved CSV inputs, explicit
+  assumptions, performance metrics, and two simple baselines (in development
+  for the v4.1.0 release).
 
 ## Requirements
 
@@ -96,6 +99,40 @@ The CLI returns a non-zero status for invalid symbols, invalid parameters, or
 market-data failures. You can also run `python -m bybit_predict analyze
 BTCUSDT`.
 
+### Backtest a historical range
+
+The v4.1.0 development branch adds a reproducible `backtest` command. It
+signals from a trailing closed-candle window, executes non-neutral signals at
+the next candle open, and exits at that candle close. The command prints its
+assumptions with metrics and baselines; it does not make a trading claim.
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --save-data data/btcusdt-2024-4h.csv
+```
+
+Re-run against the saved, normalized CSV without downloading data again:
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --data data/btcusdt-2024-4h.csv
+```
+
+`--start` is inclusive, `--end` is exclusive, and date-only values mean
+midnight UTC. See [backtesting and evaluation](docs/backtesting.md) for metric
+definitions, baseline semantics, reproducibility requirements, and important
+limitations.
+
 ## Discord slash commands
 
 Install the Discord optional dependency, create a Discord application/bot, and
@@ -153,10 +190,15 @@ Bybit V5 public API
         │
 BybitV5MarketClient ──→ normalized UTC Candles
         │
-PredictionService ──→ LegacyRuleBasedStrategy ──→ PredictionResult
-        │                         │
-        ├──────── CLI             └── future strategies / v4.1 backtesting
-        └──────── Discord slash command
+        ├── PredictionService ──→ LegacyRuleBasedStrategy ──→ PredictionResult
+        │         │                         │
+        │         ├──────── CLI             └── future strategies
+        │         └──────── Discord slash command
+        │
+        └── BacktestEngine ─────→ LegacyRuleBasedStrategy ──→ BacktestResult
+                  │
+                  ├──────── historical CLI
+                  └──────── saved CSV input/output
 ```
 
 - `market/` owns Bybit V5 requests, retry boundaries, pagination, and response
@@ -177,7 +219,7 @@ handling, and bearish Fibonacci label ordering; the exact compatibility
 baseline and retained semantics are documented in
 [legacy strategy migration notes](docs/legacy-strategy-changes.md).
 
-The planned **v4.1.0** backtesting work ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)) will define entry/exit semantics and measure directional accuracy, win rate, average return, maximum drawdown, and appropriate baselines. Until then, this project makes no quantitative claim that its signals predict future prices.
+The **v4.1.0** backtesting work ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)) defines a fixed trailing analysis window, next-open entry, same-candle-close exit, and neutral-as-cash behavior before calculating directional accuracy, win rate, average return, maximum drawdown, and a zero-risk-rate Sharpe ratio. It compares the result with buy-and-hold and a 10/20 SMA directional baseline. See [backtesting and evaluation](docs/backtesting.md) for the exact rules and limitations. Until published results are independently interpreted in context, this project makes no claim that its signals predict future prices.
 
 ## Development and quality checks
 
@@ -197,7 +239,7 @@ Pull requests run these checks on Python 3.11, 3.12, and 3.13. See
 - **v4.0.0:** package architecture, public Bybit V5 client, stateless legacy
   strategy, CLI, Discord slash command, configuration, quality gates, and
   documentation.
-- **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)).
+- **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25), in development).
 - **Later:** additional strategies may implement the same strategy contract;
   ML is a future option, not an implied feature.
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -1,0 +1,110 @@
+# Backtesting and evaluation
+
+`bybit-predict backtest` measures a deterministic strategy against historical
+OHLCV candles. It is an evaluation tool, not a trading system and not evidence
+that a strategy will remain profitable.
+
+## Reproducible inputs
+
+Every run uses an explicit UTC half-open date range: `--start` is included and
+`--end` is excluded. A date such as `2024-01-01` means `2024-01-01T00:00:00Z`.
+Offset-aware ISO-8601 timestamps are converted to UTC; naive timestamps are
+rejected.
+
+Download a range from Bybit V5 and save its normalized input once:
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --save-data data/btcusdt-2024-4h.csv
+```
+
+Run the exact same saved dataset later without a network request:
+
+```bash
+bybit-predict backtest BTCUSDT \
+  --interval 240 \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strategy legacy \
+  --window 180 \
+  --data data/btcusdt-2024-4h.csv
+```
+
+The CSV is headered and normalized as `timestamp,open,high,low,close,volume`.
+It is intentionally not created automatically or committed to Git. The caller
+is responsible for retaining the input file, command, package version, and any
+non-default fee or slippage settings needed to reproduce a report.
+
+Bybit's [V5 K-line endpoint](https://bybit-exchange.github.io/docs/v5/market/kline)
+supplies K-lines in reverse start-time order and limits each request to 1,000
+candles; the client requests pages, normalizes them to UTC, removes overlaps,
+and supplies chronological data to the engine. The public API may return a
+still-open latest candle, so choose an `--end` safely in the past when
+evaluating a completed period.
+
+## Execution model
+
+The engine uses a fixed trailing `--window` of closed candles. For each point
+in the evaluation period:
+
+1. The strategy receives only that trailing window and produces a signal at
+   its final candle close.
+2. A bullish or bearish signal enters at the **next candle open** and exits at
+   that **same candle close**. Bearish signals are simulated as short
+   positions.
+3. A neutral signal holds cash for that candle.
+
+This ordering prevents the strategy from seeing the candle used for simulated
+execution. Positions never overlap because each simulated position ends before
+the following signal can execute.
+
+The selected date range also supplies the warm-up window: the first possible
+execution is the candle immediately after `--window` candles have accumulated.
+The report's candle period therefore includes warm-up data before the first
+evaluated signal.
+
+`--fee-rate` and `--slippage-rate` are proportional, per-side values and both
+default to zero. Slippage worsens each entry and exit according to direction;
+fees subtract `2 * fee_rate` from every non-neutral gross return. The report
+prints both assumptions. It does **not** model funding, borrow costs,
+liquidation, leverage limits, exchange-specific fee tiers, spread, partial
+fills, market impact, order latency, taxes, or unavailable liquidity.
+
+## Metrics
+
+All reported returns are decimal ratios rendered as percentages.
+
+| Metric | Definition |
+| --- | --- |
+| Directional accuracy | Share of non-neutral signals whose predicted direction agrees with the next candle close versus the signal candle close. A flat next close is not a correct directional prediction. |
+| Win rate | Share of simulated trades with a strictly positive net return after declared fees and slippage. |
+| Average trade return | Arithmetic mean of simulated trade net returns. |
+| Strategy total return | Compounded return across every evaluation candle; neutral steps contribute zero return. |
+| Maximum drawdown | Largest peak-to-trough fall in the compounded strategy equity curve. |
+| Annualized Sharpe ratio | Mean per-candle strategy return divided by sample standard deviation, annualized with crypto's 365-day calendar. It is `N/A` when fewer than two returns exist or variation is zero. The risk-free rate is assumed to be zero. |
+
+The engine also reports two baselines over the same execution period:
+
+- **buy-and-hold:** buy at the first executable candle open and hold until the
+  final close, using the same declared fee and slippage assumptions;
+- **sma-10-20-direction:** go long when the 10-candle simple moving average is
+  above the 20-candle average, short when it is below, and use the same
+  next-open-to-close execution model.
+
+Baselines make a result comparable; they are not benchmarks of investment
+suitability. Do not compare runs that use different symbols, timeframes,
+datasets, windows, costs, or execution assumptions as if they were equivalent.
+
+## Limitations
+
+Historical market data is not a guarantee of future market behavior. A strategy
+can be overfit through repeated parameter selection even when every single run
+is deterministic. The legacy rule-based strategy was created as market
+analysis, not as a validated portfolio construction system. Treat results as
+engineering evidence about a precisely stated historical simulation, not as a
+recommendation to trade.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.0.0"
+version = "4.1.0a0"
 description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.0.0"
+__version__ = "4.1.0a0"

--- a/src/bybit_predict/backtest/__init__.py
+++ b/src/bybit_predict/backtest/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022-2026 CodeRyo Studio, Chien-Hsun Chang, and contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Deterministic historical evaluation for rule-based market signals."""
+
+from bybit_predict.backtest.engine import BacktestEngine
+from bybit_predict.backtest.models import BacktestResult, PerformanceMetrics
+
+__all__ = ["BacktestEngine", "BacktestResult", "PerformanceMetrics"]

--- a/src/bybit_predict/backtest/data.py
+++ b/src/bybit_predict/backtest/data.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2022-2026 CodeRyo Studio, Chien-Hsun Chang, and contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""CSV persistence and UTC date parsing for reproducible backtest inputs."""
+
+from __future__ import annotations
+
+import csv
+from datetime import UTC, date, datetime, time
+from pathlib import Path
+
+from bybit_predict.exceptions import BacktestError
+from bybit_predict.models import Candle
+
+CSV_FIELDS = ("timestamp", "open", "high", "low", "close", "volume")
+
+
+def parse_utc_datetime(value: str) -> datetime:
+    """Parse an ISO-8601 date or UTC offset-aware timestamp into UTC.
+
+    A date-only argument denotes midnight UTC. Backtest ranges use an inclusive
+    start and exclusive end, so ``--end 2025-01-01`` ends immediately before
+    that UTC date.
+    """
+    try:
+        if len(value) == 10:
+            return datetime.combine(date.fromisoformat(value), time.min, tzinfo=UTC)
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"Expected an ISO-8601 UTC date or timestamp, got {value!r}") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("Timestamp must include a UTC offset; use YYYY-MM-DD for UTC midnight")
+    return parsed.astimezone(UTC)
+
+
+def filter_candles(
+    candles: tuple[Candle, ...], *, start: datetime, end: datetime
+) -> tuple[Candle, ...]:
+    """Select chronological candles in the half-open ``[start, end)`` range."""
+    if start >= end:
+        raise BacktestError("Backtest start must be before end")
+    return tuple(candle for candle in candles if start <= candle.timestamp < end)
+
+
+def save_candles_csv(path: Path, candles: tuple[Candle, ...]) -> None:
+    """Save normalized candles in a headered, stable CSV format."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        writer.writerows(
+            {
+                "timestamp": candle.timestamp.isoformat().replace("+00:00", "Z"),
+                "open": candle.open,
+                "high": candle.high,
+                "low": candle.low,
+                "close": candle.close,
+                "volume": candle.volume,
+            }
+            for candle in candles
+        )
+
+
+def load_candles_csv(path: Path) -> tuple[Candle, ...]:
+    """Load saved normalized candles and reject malformed or duplicate rows."""
+    try:
+        with path.open(newline="", encoding="utf-8") as file:
+            reader = csv.DictReader(file)
+            if reader.fieldnames is None or tuple(reader.fieldnames) != CSV_FIELDS:
+                raise BacktestError(f"CSV must have exactly these columns: {', '.join(CSV_FIELDS)}")
+            candles = tuple(
+                _row_to_candle(row, line_number) for line_number, row in enumerate(reader, 2)
+            )
+    except OSError as error:
+        raise BacktestError(f"Could not read candle CSV {path}: {error}") from error
+    if not candles:
+        raise BacktestError("Candle CSV contains no data rows")
+    chronological = tuple(sorted(candles, key=lambda candle: candle.timestamp))
+    if len({candle.timestamp for candle in chronological}) != len(chronological):
+        raise BacktestError("Candle CSV contains duplicate timestamps")
+    return chronological
+
+
+def _row_to_candle(row: dict[str, str | None], line_number: int) -> Candle:
+    try:
+        return Candle(
+            timestamp=parse_utc_datetime(_required(row, "timestamp", line_number)),
+            open=float(_required(row, "open", line_number)),
+            high=float(_required(row, "high", line_number)),
+            low=float(_required(row, "low", line_number)),
+            close=float(_required(row, "close", line_number)),
+            volume=float(_required(row, "volume", line_number)),
+        )
+    except (TypeError, ValueError) as error:
+        raise BacktestError(f"Invalid candle data on CSV line {line_number}: {error}") from error
+
+
+def _required(row: dict[str, str | None], field: str, line_number: int) -> str:
+    value = row.get(field)
+    if value is None or not value.strip():
+        raise BacktestError(f"CSV line {line_number} has no {field} value")
+    return value

--- a/src/bybit_predict/backtest/engine.py
+++ b/src/bybit_predict/backtest/engine.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: 2022-2026 CodeRyo Studio, Chien-Hsun Chang, and contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""A no-look-ahead, one-candle execution engine for deterministic strategies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import fmean
+
+from bybit_predict.backtest.metrics import annualized_sharpe, maximum_drawdown, periods_per_year
+from bybit_predict.backtest.models import (
+    BacktestAssumptions,
+    BacktestResult,
+    BaselineResult,
+    EquityPoint,
+    PerformanceMetrics,
+    Trade,
+)
+from bybit_predict.exceptions import BacktestError
+from bybit_predict.models import Candle, SignalTrend
+from bybit_predict.strategies.base import Strategy
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestEngine:
+    """Evaluate a strategy without allowing a signal to see its execution candle."""
+
+    strategy: Strategy
+    analysis_window: int = 180
+    fee_rate: float = 0.0
+    slippage_rate: float = 0.0
+
+    def __post_init__(self) -> None:
+        minimum = getattr(self.strategy, "minimum_candles", 1)
+        if self.analysis_window < minimum:
+            raise ValueError(
+                f"analysis_window must be at least the strategy minimum of {minimum} candles"
+            )
+        if self.fee_rate < 0 or self.slippage_rate < 0:
+            raise ValueError("fee_rate and slippage_rate cannot be negative")
+
+    def run(self, candles: tuple[Candle, ...], *, symbol: str, interval: str) -> BacktestResult:
+        """Run expanding historical signals using a fixed trailing analysis window.
+
+        A signal is calculated only after its window has closed. A non-neutral
+        result enters at the next candle's open and exits at that same candle's
+        close. Neutral signals remain in cash for that candle. This deliberately
+        prevents the strategy from using an execution candle to create its signal.
+        """
+        self._validate_candles(candles)
+        assumptions = BacktestAssumptions(
+            analysis_window=self.analysis_window,
+            fee_rate=self.fee_rate,
+            slippage_rate=self.slippage_rate,
+        )
+        trades: list[Trade] = []
+        step_returns: list[float] = []
+        directional_matches: list[bool] = []
+        equity = 1.0
+        equity_curve: list[EquityPoint] = []
+
+        for signal_index in range(self.analysis_window - 1, len(candles) - 1):
+            window = candles[signal_index - self.analysis_window + 1 : signal_index + 1]
+            signal = self.strategy.analyze(window, symbol=symbol, interval=interval)
+            execution = candles[signal_index + 1]
+            step_return = 0.0
+            if signal.trend is not SignalTrend.NEUTRAL:
+                directional_matches.append(
+                    self._is_directionally_correct(signal.trend, window[-1].close, execution.close)
+                )
+                trade = self._trade(signal.trend, window[-1], execution)
+                trades.append(trade)
+                step_return = trade.net_return
+            equity *= 1 + step_return
+            step_returns.append(step_return)
+            equity_curve.append(EquityPoint(timestamp=execution.timestamp, value=equity))
+
+        metrics = self._metrics(
+            trades=tuple(trades),
+            step_returns=tuple(step_returns),
+            directional_matches=tuple(directional_matches),
+            equity_curve=tuple(equity_curve),
+            interval=interval,
+        )
+        return BacktestResult(
+            symbol=symbol.upper(),
+            interval=str(interval).upper(),
+            strategy=self.strategy.name,
+            period_start=candles[0].timestamp,
+            period_end=candles[-1].timestamp,
+            candle_count=len(candles),
+            signal_count=len(step_returns),
+            trade_count=len(trades),
+            assumptions=assumptions,
+            metrics=metrics,
+            baselines=self._baselines(candles, interval),
+            trades=tuple(trades),
+            equity_curve=tuple(equity_curve),
+        )
+
+    def _trade(self, trend: SignalTrend, signal_candle: Candle, execution: Candle) -> Trade:
+        entry_price = self._entry_price(execution.open, trend)
+        exit_price = self._exit_price(execution.close, trend)
+        if entry_price <= 0 or exit_price <= 0:
+            raise BacktestError("Backtesting requires strictly positive execution prices")
+        gross_return = (
+            exit_price / entry_price - 1
+            if trend is SignalTrend.BULLISH
+            else entry_price / exit_price - 1
+        )
+        net_return = gross_return - 2 * self.fee_rate
+        return Trade(
+            signal_timestamp=signal_candle.timestamp,
+            entry_timestamp=execution.timestamp,
+            exit_timestamp=execution.timestamp,
+            trend=trend,
+            entry_price=entry_price,
+            exit_price=exit_price,
+            gross_return=gross_return,
+            net_return=net_return,
+        )
+
+    def _entry_price(self, price: float, trend: SignalTrend) -> float:
+        adjustment = (
+            1 + self.slippage_rate if trend is SignalTrend.BULLISH else 1 - self.slippage_rate
+        )
+        return price * adjustment
+
+    def _exit_price(self, price: float, trend: SignalTrend) -> float:
+        adjustment = (
+            1 - self.slippage_rate if trend is SignalTrend.BULLISH else 1 + self.slippage_rate
+        )
+        return price * adjustment
+
+    @staticmethod
+    def _is_directionally_correct(
+        trend: SignalTrend, prior_close: float, future_close: float
+    ) -> bool:
+        return (trend is SignalTrend.BULLISH and future_close > prior_close) or (
+            trend is SignalTrend.BEARISH and future_close < prior_close
+        )
+
+    def _metrics(
+        self,
+        *,
+        trades: tuple[Trade, ...],
+        step_returns: tuple[float, ...],
+        directional_matches: tuple[bool, ...],
+        equity_curve: tuple[EquityPoint, ...],
+        interval: str,
+    ) -> PerformanceMetrics:
+        return PerformanceMetrics(
+            directional_accuracy=(fmean(directional_matches) if directional_matches else None),
+            win_rate=(fmean(trade.net_return > 0 for trade in trades) if trades else None),
+            average_trade_return=(fmean(trade.net_return for trade in trades) if trades else None),
+            total_return=(equity_curve[-1].value - 1 if equity_curve else 0.0),
+            maximum_drawdown=maximum_drawdown(tuple(point.value for point in equity_curve)),
+            sharpe_ratio=annualized_sharpe(step_returns, periods_per_year(interval)),
+        )
+
+    def _baselines(self, candles: tuple[Candle, ...], interval: str) -> tuple[BaselineResult, ...]:
+        first_execution = candles[self.analysis_window]
+        if first_execution.open <= 0 or candles[-1].close <= 0:
+            raise BacktestError("Backtesting baselines require strictly positive prices")
+        buy_and_hold_entry = self._entry_price(first_execution.open, SignalTrend.BULLISH)
+        buy_and_hold_exit = self._exit_price(candles[-1].close, SignalTrend.BULLISH)
+        buy_and_hold = buy_and_hold_exit / buy_and_hold_entry - 1 - 2 * self.fee_rate
+        sma_return, sma_trades = self._sma_direction_return(candles)
+        return (
+            BaselineResult(
+                name="buy-and-hold",
+                description=(
+                    "Buy at the first executable candle open and hold to the final close, "
+                    "using the declared fee and slippage assumptions."
+                ),
+                total_return=buy_and_hold,
+                trade_count=1,
+            ),
+            BaselineResult(
+                name="sma-10-20-direction",
+                description=(
+                    "Long when the 10-candle SMA exceeds the 20-candle SMA, short when below; "
+                    "uses the same next-open to close execution model."
+                ),
+                total_return=sma_return,
+                trade_count=sma_trades,
+            ),
+        )
+
+    def _sma_direction_return(self, candles: tuple[Candle, ...]) -> tuple[float, int]:
+        equity = 1.0
+        trade_count = 0
+        for signal_index in range(self.analysis_window - 1, len(candles) - 1):
+            closes = tuple(candle.close for candle in candles[: signal_index + 1])
+            short_average = fmean(closes[-10:])
+            long_average = fmean(closes[-20:])
+            if short_average == long_average:
+                continue
+            trend = SignalTrend.BULLISH if short_average > long_average else SignalTrend.BEARISH
+            trade = self._trade(trend, candles[signal_index], candles[signal_index + 1])
+            equity *= 1 + trade.net_return
+            trade_count += 1
+        return equity - 1, trade_count
+
+    def _validate_candles(self, candles: tuple[Candle, ...]) -> None:
+        if len(candles) <= self.analysis_window:
+            raise BacktestError(
+                "Backtesting requires more candles than the analysis window so at least one "
+                "signal can be executed"
+            )
+        if any(
+            first.timestamp >= second.timestamp
+            for first, second in zip(candles, candles[1:], strict=False)
+        ):
+            raise BacktestError("Candles must be in strictly ascending chronological order")

--- a/src/bybit_predict/backtest/metrics.py
+++ b/src/bybit_predict/backtest/metrics.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022-2026 CodeRyo Studio, Chien-Hsun Chang, and contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Pure metric calculations used by the backtesting engine."""
+
+from __future__ import annotations
+
+from math import sqrt
+from statistics import fmean, stdev
+
+
+def maximum_drawdown(equity_values: tuple[float, ...]) -> float:
+    """Return the largest peak-to-trough drawdown as a negative return."""
+    if not equity_values:
+        return 0.0
+    peak = equity_values[0]
+    drawdown = 0.0
+    for value in equity_values:
+        peak = max(peak, value)
+        if peak:
+            drawdown = min(drawdown, value / peak - 1)
+    return drawdown
+
+
+def annualized_sharpe(returns: tuple[float, ...], periods_per_year: float) -> float | None:
+    """Calculate a zero-risk-rate Sharpe ratio, or ``None`` when undefined."""
+    if len(returns) < 2:
+        return None
+    dispersion = stdev(returns)
+    if dispersion == 0:
+        return None
+    return fmean(returns) / dispersion * sqrt(periods_per_year)
+
+
+def periods_per_year(interval: str) -> float:
+    """Return crypto-market periods per year for a documented Bybit interval."""
+    normalized = str(interval).upper()
+    calendar_periods = {"D": 365.0, "W": 52.0, "M": 12.0}
+    if normalized in calendar_periods:
+        return calendar_periods[normalized]
+    minutes = int(normalized)
+    return 365.0 * 24 * 60 / minutes

--- a/src/bybit_predict/backtest/models.py
+++ b/src/bybit_predict/backtest/models.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2022-2026 CodeRyo Studio, Chien-Hsun Chang, and contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Immutable result models for reproducible historical evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from bybit_predict.models import SignalTrend
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestAssumptions:
+    """The execution model applied to every result in a backtest run."""
+
+    analysis_window: int
+    entry_rule: str = "next candle open"
+    exit_rule: str = "same candle close"
+    fee_rate: float = 0.0
+    slippage_rate: float = 0.0
+    allows_short: bool = True
+
+    def __post_init__(self) -> None:
+        if self.analysis_window < 1:
+            raise ValueError("analysis_window must be positive")
+        if self.fee_rate < 0 or self.slippage_rate < 0:
+            raise ValueError("fee_rate and slippage_rate cannot be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class Trade:
+    """One non-neutral, one-candle simulated position."""
+
+    signal_timestamp: datetime
+    entry_timestamp: datetime
+    exit_timestamp: datetime
+    trend: SignalTrend
+    entry_price: float
+    exit_price: float
+    gross_return: float
+    net_return: float
+
+    def __post_init__(self) -> None:
+        if self.trend is SignalTrend.NEUTRAL:
+            raise ValueError("A trade must have a bullish or bearish trend")
+        if self.entry_price <= 0 or self.exit_price <= 0:
+            raise ValueError("Trade prices must be positive")
+        if self.entry_timestamp > self.exit_timestamp:
+            raise ValueError("Trade exit cannot precede entry")
+
+
+@dataclass(frozen=True, slots=True)
+class EquityPoint:
+    """The compounded strategy value after one evaluated candle."""
+
+    timestamp: datetime
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class PerformanceMetrics:
+    """Metrics calculated from the declared execution model, never forecasts."""
+
+    directional_accuracy: float | None
+    win_rate: float | None
+    average_trade_return: float | None
+    total_return: float
+    maximum_drawdown: float
+    sharpe_ratio: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineResult:
+    """A simple comparison result calculated over the same evaluation period."""
+
+    name: str
+    description: str
+    total_return: float
+    trade_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestResult:
+    """A complete deterministic evaluation result and its explicit assumptions."""
+
+    symbol: str
+    interval: str
+    strategy: str
+    period_start: datetime
+    period_end: datetime
+    candle_count: int
+    signal_count: int
+    trade_count: int
+    assumptions: BacktestAssumptions
+    metrics: PerformanceMetrics
+    baselines: tuple[BaselineResult, ...]
+    trades: tuple[Trade, ...]
+    equity_curve: tuple[EquityPoint, ...]

--- a/src/bybit_predict/cli.py
+++ b/src/bybit_predict/cli.py
@@ -7,12 +7,22 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Callable, Sequence
+from pathlib import Path
 
+from bybit_predict.backtest.data import (
+    filter_candles,
+    load_candles_csv,
+    parse_utc_datetime,
+    save_candles_csv,
+)
+from bybit_predict.backtest.engine import BacktestEngine
 from bybit_predict.config import bybit_testnet_enabled
-from bybit_predict.exceptions import BybitPredictError
+from bybit_predict.exceptions import BybitPredictError, SymbolNotFoundError
+from bybit_predict.market.base import HistoricalMarketDataClient
 from bybit_predict.market.bybit import BybitV5MarketClient
-from bybit_predict.presentation import format_result_text
+from bybit_predict.presentation import format_backtest_result_text, format_result_text
 from bybit_predict.services.predictor import PredictionService
+from bybit_predict.strategies.legacy import LegacyRuleBasedStrategy
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -35,6 +45,47 @@ def build_parser() -> argparse.ArgumentParser:
         default=180,
         help="Number of candles to fetch, from 42 to 1000 (default: 180)",
     )
+    backtest = subcommands.add_parser(
+        "backtest", help="Evaluate a strategy on a historical UTC date range"
+    )
+    backtest.add_argument("symbol", help="Bybit symbol, for example BTCUSDT")
+    backtest.add_argument("--start", required=True, help="Inclusive UTC ISO-8601 date or timestamp")
+    backtest.add_argument("--end", required=True, help="Exclusive UTC ISO-8601 date or timestamp")
+    backtest.add_argument("--interval", default="240", help="Bybit K-line interval (default: 240)")
+    backtest.add_argument(
+        "--window",
+        type=int,
+        default=180,
+        help="Closed candles used for each strategy signal (default: 180)",
+    )
+    backtest.add_argument(
+        "--strategy",
+        choices=("legacy",),
+        default="legacy",
+        help="Strategy to evaluate (default: legacy)",
+    )
+    backtest.add_argument(
+        "--data",
+        type=Path,
+        help="Use a previously saved normalized candle CSV instead of downloading data",
+    )
+    backtest.add_argument(
+        "--save-data",
+        type=Path,
+        help="Save downloaded normalized candles as CSV for a reproducible rerun",
+    )
+    backtest.add_argument(
+        "--fee-rate",
+        type=float,
+        default=0.0,
+        help="Per-side proportional fee used in simulated trades (default: 0)",
+    )
+    backtest.add_argument(
+        "--slippage-rate",
+        type=float,
+        default=0.0,
+        help="Per-side proportional slippage used in simulated trades (default: 0)",
+    )
     subcommands.add_parser("discord", help="Run the optional Discord slash-command bot")
     return parser
 
@@ -43,6 +94,7 @@ def main(
     argv: Sequence[str] | None = None,
     *,
     service_factory: Callable[[], PredictionService] | None = None,
+    market_factory: Callable[[], HistoricalMarketDataClient] | None = None,
 ) -> int:
     """Run the CLI and return a process status without leaking tracebacks to users."""
     parser = build_parser()
@@ -57,6 +109,9 @@ def main(
             print(f"Configuration error: {error}", file=sys.stderr)
             return 1
         return 0
+
+    if arguments.command == "backtest":
+        return _run_backtest(arguments, market_factory=market_factory)
 
     if arguments.limit < 42 or arguments.limit > 1000:
         print(
@@ -79,3 +134,45 @@ def main(
 
 def _default_service() -> PredictionService:
     return PredictionService(BybitV5MarketClient(testnet=bybit_testnet_enabled()))
+
+
+def _run_backtest(
+    arguments: argparse.Namespace,
+    *,
+    market_factory: Callable[[], HistoricalMarketDataClient] | None,
+) -> int:
+    """Run one explicit historical evaluation and present only measured outcomes."""
+    try:
+        start = parse_utc_datetime(arguments.start)
+        end = parse_utc_datetime(arguments.end)
+        if arguments.data is not None and arguments.save_data is not None:
+            raise ValueError("--data and --save-data cannot be used together")
+        if arguments.data is not None:
+            candles = filter_candles(load_candles_csv(arguments.data), start=start, end=end)
+        else:
+            market = market_factory() if market_factory is not None else _default_market_client()
+            symbol = arguments.symbol.strip().upper()
+            if not market.is_valid_symbol(symbol):
+                subject = symbol or "The requested symbol"
+                raise SymbolNotFoundError(f"{subject} is not an active Bybit symbol")
+            candles = market.get_historical_candles(
+                symbol, interval=arguments.interval, start=start, end=end
+            )
+            if arguments.save_data is not None:
+                save_candles_csv(arguments.save_data, candles)
+        engine = BacktestEngine(
+            LegacyRuleBasedStrategy(),
+            analysis_window=arguments.window,
+            fee_rate=arguments.fee_rate,
+            slippage_rate=arguments.slippage_rate,
+        )
+        result = engine.run(candles, symbol=arguments.symbol, interval=arguments.interval)
+    except (BybitPredictError, OSError, ValueError) as error:
+        print(f"Backtest failed: {error}", file=sys.stderr)
+        return 1
+    print(format_backtest_result_text(result))
+    return 0
+
+
+def _default_market_client() -> BybitV5MarketClient:
+    return BybitV5MarketClient(testnet=bybit_testnet_enabled())

--- a/src/bybit_predict/exceptions.py
+++ b/src/bybit_predict/exceptions.py
@@ -21,3 +21,7 @@ class SymbolNotFoundError(MarketDataError):
 
 class InsufficientDataError(BybitPredictError):
     """Raised when a strategy lacks enough candles for a valid analysis."""
+
+
+class BacktestError(BybitPredictError):
+    """Raised when backtest input or execution semantics are invalid."""

--- a/src/bybit_predict/market/base.py
+++ b/src/bybit_predict/market/base.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Protocol
 
 from bybit_predict.models import Candle
@@ -18,4 +19,14 @@ class MarketDataClient(Protocol):
 
     def is_valid_symbol(self, symbol: str) -> bool:
         """Return whether a symbol is currently available for analysis."""
+        ...
+
+
+class HistoricalMarketDataClient(MarketDataClient, Protocol):
+    """A market-data source that can retrieve a bounded historical UTC range."""
+
+    def get_historical_candles(
+        self, symbol: str, *, interval: str, start: datetime, end: datetime
+    ) -> tuple[Candle, ...]:
+        """Return candles whose start timestamps are in ``[start, end)``."""
         ...

--- a/src/bybit_predict/market/bybit.py
+++ b/src/bybit_predict/market/bybit.py
@@ -87,6 +87,53 @@ class BybitV5MarketClient:
             raise MarketDataError(f"Bybit returned no candles for {normalized_symbol}")
         return tuple(sorted(candles, key=lambda candle: candle.timestamp))
 
+    def get_historical_candles(
+        self, symbol: str, *, interval: str, start: datetime, end: datetime
+    ) -> tuple[Candle, ...]:
+        """Fetch an explicit UTC range, following Bybit's 1,000-candle pages.
+
+        Bybit returns each page newest-first. The next request moves its
+        inclusive end just before the oldest received candle, then normalized
+        results are de-duplicated and returned in chronological order.
+        """
+        normalized_symbol = self._normalize_symbol(symbol)
+        normalized_interval = self._validate_interval(interval)
+        self._validate_range(start, end)
+        start_ms = int(start.timestamp() * 1000)
+        page_end_ms = int(end.timestamp() * 1000) - 1
+        by_timestamp: dict[datetime, Candle] = {}
+
+        while page_end_ms >= start_ms:
+            response = self._request(
+                self._session.get_kline,
+                category=self._category,
+                symbol=normalized_symbol,
+                interval=normalized_interval,
+                start=start_ms,
+                end=page_end_ms,
+                limit=1000,
+            )
+            rows = self._result_list(response, endpoint="get_kline")
+            page = tuple(self._to_candle(row) for row in rows)
+            if not page:
+                break
+            for candle in page:
+                if start <= candle.timestamp < end:
+                    by_timestamp[candle.timestamp] = candle
+            oldest_ms = min(int(candle.timestamp.timestamp() * 1000) for candle in page)
+            if oldest_ms <= start_ms:
+                break
+            if oldest_ms >= page_end_ms:
+                raise MarketDataError("Bybit historical pagination did not advance")
+            page_end_ms = oldest_ms - 1
+
+        candles = tuple(sorted(by_timestamp.values(), key=lambda candle: candle.timestamp))
+        if not candles:
+            raise MarketDataError(
+                f"Bybit returned no candles for {normalized_symbol} in the requested date range"
+            )
+        return candles
+
     def is_valid_symbol(self, symbol: str) -> bool:
         """Check an individual symbol against Bybit's current instrument metadata."""
         normalized_symbol = self._normalize_symbol(symbol)
@@ -159,6 +206,17 @@ class BybitV5MarketClient:
             allowed = ", ".join(sorted(SUPPORTED_INTERVALS))
             raise ValueError(f"Unsupported Bybit interval {interval!r}. Expected one of: {allowed}")
         return normalized
+
+    @staticmethod
+    def _validate_range(start: datetime, end: datetime) -> None:
+        if start.tzinfo is None or start.utcoffset() is None:
+            raise ValueError("Historical start must be timezone-aware")
+        if end.tzinfo is None or end.utcoffset() is None:
+            raise ValueError("Historical end must be timezone-aware")
+        if start.utcoffset() != UTC.utcoffset(start) or end.utcoffset() != UTC.utcoffset(end):
+            raise ValueError("Historical dates must be in UTC")
+        if start >= end:
+            raise ValueError("Historical start must be before end")
 
     @staticmethod
     def _raise_for_api_error(response: Mapping[str, Any]) -> None:

--- a/src/bybit_predict/presentation.py
+++ b/src/bybit_predict/presentation.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from bybit_predict.backtest.models import BacktestResult
 from bybit_predict.models import PredictionResult, SignalTrend
 
 DISPLAY_TRENDS = {
@@ -43,3 +44,55 @@ def format_result_text(result: PredictionResult) -> str:
         ]
     )
     return "\n".join(lines)
+
+
+def format_backtest_result_text(result: BacktestResult) -> str:
+    """Return a readable report that keeps backtest assumptions beside metrics."""
+    metrics = result.metrics
+    lines = [
+        f"Symbol: {result.symbol}",
+        f"Strategy: {result.strategy} (rule-based, not ML)",
+        f"Timeframe: {result.interval}",
+        f"Candles: {result.candle_count}",
+        f"Period (UTC): {result.period_start.isoformat()} -> {result.period_end.isoformat()}",
+        f"Signals evaluated: {result.signal_count}",
+        f"Trades: {result.trade_count}",
+        "",
+        "Assumptions:",
+        f"  Analysis window: {result.assumptions.analysis_window} closed candles",
+        f"  Entry: {result.assumptions.entry_rule}",
+        f"  Exit: {result.assumptions.exit_rule}",
+        f"  Fee rate per side: {result.assumptions.fee_rate:.4%}",
+        f"  Slippage per side: {result.assumptions.slippage_rate:.4%}",
+        "",
+        "Performance:",
+        f"  Directional accuracy: {_format_percentage(metrics.directional_accuracy)}",
+        f"  Win rate: {_format_percentage(metrics.win_rate)}",
+        f"  Average trade return: {_format_percentage(metrics.average_trade_return)}",
+        f"  Strategy total return: {_format_percentage(metrics.total_return)}",
+        f"  Maximum drawdown: {_format_percentage(metrics.maximum_drawdown)}",
+        f"  Annualized Sharpe ratio: {_format_number(metrics.sharpe_ratio)}",
+        "",
+        "Baselines:",
+    ]
+    lines.extend(
+        f"  {baseline.name}: {_format_percentage(baseline.total_return)}"
+        + (f" ({baseline.trade_count} trades)" if baseline.trade_count is not None else "")
+        for baseline in result.baselines
+    )
+    lines.extend(
+        [
+            "",
+            "Historical results use the assumptions above; they are not financial advice",
+            "or a guarantee of future performance.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _format_percentage(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.2%}"
+
+
+def _format_number(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.3f}"

--- a/src/bybit_predict/strategies/base.py
+++ b/src/bybit_predict/strategies/base.py
@@ -12,7 +12,10 @@ from bybit_predict.models import Candle, PredictionResult
 class Strategy(Protocol):
     """A deterministic market-analysis strategy."""
 
-    name: str
+    @property
+    def name(self) -> str:
+        """A stable identifier for reports and backtest comparisons."""
+        ...
 
     def analyze(
         self, candles: tuple[Candle, ...], *, symbol: str, interval: str

--- a/tests/unit/test_backtest_data.py
+++ b/tests/unit/test_backtest_data.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bybit_predict.backtest.data import (
+    filter_candles,
+    load_candles_csv,
+    parse_utc_datetime,
+    save_candles_csv,
+)
+from bybit_predict.exceptions import BacktestError
+from bybit_predict.models import Candle
+
+
+def test_csv_round_trip_is_stable_and_date_filter_is_half_open(tmp_path: Path) -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    candles = tuple(
+        Candle(
+            timestamp=start + timedelta(hours=4 * index),
+            open=10 + index,
+            high=12 + index,
+            low=9 + index,
+            close=11 + index,
+            volume=100 + index,
+        )
+        for index in range(3)
+    )
+    path = tmp_path / "candles.csv"
+
+    save_candles_csv(path, candles)
+
+    assert load_candles_csv(path) == candles
+    assert filter_candles(candles, start=candles[1].timestamp, end=candles[2].timestamp) == (
+        candles[1],
+    )
+
+
+def test_csv_rejects_duplicate_timestamps(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.csv"
+    path.write_text(
+        "timestamp,open,high,low,close,volume\n"
+        "2024-01-01T00:00:00Z,1,2,0.5,1.5,1\n"
+        "2024-01-01T00:00:00Z,1,2,0.5,1.5,1\n"
+    )
+
+    with pytest.raises(BacktestError, match="duplicate"):
+        load_candles_csv(path)
+
+
+def test_parse_utc_datetime_handles_dates_and_rejects_naive_timestamps() -> None:
+    assert parse_utc_datetime("2024-01-02") == datetime(2024, 1, 2, tzinfo=UTC)
+    assert parse_utc_datetime("2024-01-02T08:00:00+08:00") == datetime(2024, 1, 2, tzinfo=UTC)
+    with pytest.raises(ValueError, match="UTC offset"):
+        parse_utc_datetime("2024-01-02T00:00:00")

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from bybit_predict.backtest.engine import BacktestEngine
+from bybit_predict.backtest.metrics import annualized_sharpe, maximum_drawdown, periods_per_year
+from bybit_predict.exceptions import BacktestError
+from bybit_predict.models import Candle, PredictionResult, SignalTrend
+
+
+def candle(index: int, *, open_price: float, close: float) -> Candle:
+    return Candle(
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=4 * index),
+        open=open_price,
+        high=max(open_price, close) + 1,
+        low=min(open_price, close) - 1,
+        close=close,
+        volume=100 + index,
+    )
+
+
+def result_for(candles: tuple[Candle, ...], trend: SignalTrend) -> PredictionResult:
+    return PredictionResult(
+        symbol="BTCUSDT",
+        interval="240",
+        strategy="test-strategy",
+        trend=trend,
+        signal_strength=1.0 if trend is not SignalTrend.NEUTRAL else 0.0,
+        candle_count=len(candles),
+        period_start=candles[0].timestamp,
+        period_end=candles[-1].timestamp,
+        bullish_power=1.0,
+        bearish_power=0.0,
+        reference_levels=(),
+        time_references=(),
+    )
+
+
+@dataclass
+class FixedStrategy:
+    trend: SignalTrend
+    name: str = "fixed"
+    minimum_candles: int = 2
+    windows: list[tuple[Candle, ...]] = field(default_factory=list)
+
+    def analyze(
+        self, candles: tuple[Candle, ...], *, symbol: str, interval: str
+    ) -> PredictionResult:
+        self.windows.append(candles)
+        return result_for(candles, self.trend)
+
+
+def test_engine_uses_closed_trailing_window_then_next_candle_execution() -> None:
+    candles = (
+        candle(0, open_price=10, close=10),
+        candle(1, open_price=10, close=11),
+        candle(2, open_price=12, close=13),
+        candle(3, open_price=13, close=12),
+    )
+    strategy = FixedStrategy(SignalTrend.BULLISH)
+
+    result = BacktestEngine(strategy, analysis_window=2).run(
+        candles, symbol="BTCUSDT", interval="240"
+    )
+
+    assert [tuple(item.timestamp for item in window) for window in strategy.windows] == [
+        (candles[0].timestamp, candles[1].timestamp),
+        (candles[1].timestamp, candles[2].timestamp),
+    ]
+    assert result.signal_count == 2
+    assert result.trade_count == 2
+    assert result.trades[0].signal_timestamp == candles[1].timestamp
+    assert result.trades[0].entry_timestamp == candles[2].timestamp
+    assert result.trades[0].entry_price == 12
+    assert result.trades[0].exit_price == 13
+    assert result.metrics.directional_accuracy == pytest.approx(0.5)
+    assert result.metrics.win_rate == pytest.approx(0.5)
+    assert result.metrics.total_return == pytest.approx(0.0)
+    assert result.baselines[0].name == "buy-and-hold"
+    assert result.baselines[0].total_return == pytest.approx(0.0)
+
+
+def test_engine_keeps_neutral_signals_in_cash_and_marks_inapplicable_metrics() -> None:
+    candles = tuple(candle(index, open_price=10 + index, close=10 + index) for index in range(4))
+
+    result = BacktestEngine(FixedStrategy(SignalTrend.NEUTRAL), analysis_window=2).run(
+        candles, symbol="BTCUSDT", interval="240"
+    )
+
+    assert result.trade_count == 0
+    assert result.metrics.directional_accuracy is None
+    assert result.metrics.win_rate is None
+    assert result.metrics.average_trade_return is None
+    assert result.metrics.total_return == 0
+    assert result.metrics.maximum_drawdown == 0
+    assert result.metrics.sharpe_ratio is None
+
+
+def test_engine_applies_fee_and_slippage_to_trade_returns() -> None:
+    candles = (
+        candle(0, open_price=10, close=10),
+        candle(1, open_price=10, close=11),
+        candle(2, open_price=12, close=13),
+    )
+
+    result = BacktestEngine(
+        FixedStrategy(SignalTrend.BULLISH), analysis_window=2, fee_rate=0.01, slippage_rate=0.01
+    ).run(candles, symbol="BTCUSDT", interval="240")
+
+    trade = result.trades[0]
+    assert trade.entry_price == pytest.approx(12.12)
+    assert trade.exit_price == pytest.approx(12.87)
+    assert trade.net_return == pytest.approx(trade.gross_return - 0.02)
+    assert result.assumptions.fee_rate == 0.01
+    assert result.assumptions.slippage_rate == 0.01
+    assert result.baselines[0].total_return == pytest.approx(12.87 / 12.12 - 1 - 0.02)
+
+
+def test_engine_requires_one_execution_candle_after_its_window() -> None:
+    candles = (candle(0, open_price=10, close=10), candle(1, open_price=10, close=11))
+
+    with pytest.raises(BacktestError, match="more candles"):
+        BacktestEngine(FixedStrategy(SignalTrend.BULLISH), analysis_window=2).run(
+            candles, symbol="BTCUSDT", interval="240"
+        )
+
+
+def test_metric_helpers_cover_drawdown_sharpe_and_interval_scaling() -> None:
+    assert maximum_drawdown((1.0, 1.2, 0.9, 1.1)) == pytest.approx(-0.25)
+    assert annualized_sharpe((0.0, 0.0), 365) is None
+    assert annualized_sharpe((0.01, -0.01, 0.02), 365) is not None
+    assert periods_per_year("240") == 2190
+    assert periods_per_year("D") == 365

--- a/tests/unit/test_cli_and_presentation.py
+++ b/tests/unit/test_cli_and_presentation.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from datetime import timedelta
+from pathlib import Path
+
 from bybit_predict.cli import main
+from bybit_predict.models import Candle
 from bybit_predict.presentation import format_result_text
 from bybit_predict.services.predictor import PredictionService
 
@@ -38,3 +42,83 @@ def test_presentation_labels_rule_based_results(candles: tuple) -> None:
 
     assert "rule-based, not ML" in format_result_text(result)
     assert "not financial advice" in format_result_text(result)
+
+
+def test_backtest_cli_downloads_and_optionally_saves_reproducible_data(
+    candles: tuple[Candle, ...], tmp_path: Path, capsys: object
+) -> None:
+    next_candle = Candle(
+        timestamp=candles[-1].timestamp + timedelta(hours=4),
+        open=candles[-1].close,
+        high=candles[-1].close + 2,
+        low=candles[-1].close - 1,
+        close=candles[-1].close + 1,
+        volume=candles[-1].volume + 1,
+    )
+    historical = candles + (next_candle,)
+
+    class Market:
+        def is_valid_symbol(self, symbol: str) -> bool:
+            return symbol == "BTCUSDT"
+
+        def get_candles(self, symbol: str, interval: str, limit: int) -> tuple[Candle, ...]:
+            raise AssertionError("Live analysis data should not be requested by backtest")
+
+        def get_historical_candles(
+            self, symbol: str, *, interval: str, start: object, end: object
+        ) -> tuple[Candle, ...]:
+            assert symbol == "BTCUSDT"
+            assert interval == "240"
+            return historical
+
+    saved = tmp_path / "btc-2026.csv"
+    status = main(
+        [
+            "backtest",
+            "BTCUSDT",
+            "--start",
+            "2026-01-01",
+            "--end",
+            "2026-01-10",
+            "--window",
+            "42",
+            "--save-data",
+            str(saved),
+        ],
+        market_factory=lambda: Market(),  # type: ignore[return-value]
+    )
+
+    assert status == 0
+    assert saved.is_file()
+    assert "Performance:" in capsys.readouterr().out  # type: ignore[attr-defined]
+
+    class NoNetworkMarket:
+        def is_valid_symbol(self, symbol: str) -> bool:
+            raise AssertionError("A saved-data backtest must not validate against the live API")
+
+        def get_candles(self, symbol: str, interval: str, limit: int) -> tuple[Candle, ...]:
+            raise AssertionError("A saved-data backtest must not fetch live candles")
+
+        def get_historical_candles(
+            self, symbol: str, *, interval: str, start: object, end: object
+        ) -> tuple[Candle, ...]:
+            raise AssertionError("A saved-data backtest must not fetch historical candles")
+
+    offline_status = main(
+        [
+            "backtest",
+            "BTCUSDT",
+            "--start",
+            "2026-01-01",
+            "--end",
+            "2026-01-10",
+            "--window",
+            "42",
+            "--data",
+            str(saved),
+        ],
+        market_factory=lambda: NoNetworkMarket(),  # type: ignore[return-value]
+    )
+
+    assert offline_status == 0
+    assert "Performance:" in capsys.readouterr().out  # type: ignore[attr-defined]

--- a/tests/unit/test_market_bybit.py
+++ b/tests/unit/test_market_bybit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -79,6 +80,56 @@ def test_get_candles_rejects_bybit_api_error() -> None:
 
     with pytest.raises(MarketDataError, match="10001"):
         client.get_candles("BTCUSDT")
+
+
+def test_get_historical_candles_follows_reverse_ordered_pages() -> None:
+    session = FakeSession(
+        klines=[
+            {
+                "retCode": 0,
+                "result": {
+                    "list": [
+                        ["4000", "4", "5", "3", "4.5", "1"],
+                        ["3000", "3", "4", "2", "3.5", "1"],
+                    ]
+                },
+            },
+            {
+                "retCode": 0,
+                "result": {
+                    "list": [
+                        ["2000", "2", "3", "1", "2.5", "1"],
+                        ["1000", "1", "2", "0.5", "1.5", "1"],
+                    ]
+                },
+            },
+        ]
+    )
+    client = BybitV5MarketClient(session=session, sleep=lambda _: None)
+    start = datetime.fromtimestamp(1, tz=UTC)
+    end = datetime.fromtimestamp(5, tz=UTC)
+
+    candles = client.get_historical_candles("BTCUSDT", interval="240", start=start, end=end)
+
+    assert [candle.open for candle in candles] == [1.0, 2.0, 3.0, 4.0]
+    assert session.kline_calls == [
+        {
+            "category": "linear",
+            "symbol": "BTCUSDT",
+            "interval": "240",
+            "start": 1000,
+            "end": 4999,
+            "limit": 1000,
+        },
+        {
+            "category": "linear",
+            "symbol": "BTCUSDT",
+            "interval": "240",
+            "start": 1000,
+            "end": 2999,
+            "limit": 1000,
+        },
+    ]
 
 
 def test_symbol_validation_uses_bybit_instrument_metadata() -> None:

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,4 +11,4 @@ def test_runtime_version_matches_package_metadata() -> None:
     with (project_root / "pyproject.toml").open("rb") as file:
         metadata = tomllib.load(file)
 
-    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.0.0"
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.0a0"


### PR DESCRIPTION
## Summary

Implements #25 for the v4.1.0 release line (package version `4.1.0a0` during development).

- Adds a deterministic `BacktestEngine` for the existing legacy strategy: trailing closed-candle window, next-open entry, same-candle-close exit, neutral-as-cash, optional fee and slippage assumptions.
- Adds historical Bybit V5 range pagination plus explicit UTC start/end handling, and headered CSV save/load so a run can be repeated without downloading data.
- Adds `bybit-predict backtest` with symbol, interval, date range, strategy, window, CSV, fee, and slippage options.
- Reports directional accuracy, win rate, average trade return, compounded total return, maximum drawdown, zero-risk-rate annualized Sharpe ratio, buy-and-hold, and a 10/20 SMA direction baseline.
- Documents execution semantics, metrics, reproducibility requirements, limitations, and the updated architecture in English and Traditional Chinese.

## Deliberate semantics

A signal only observes its preceding fixed window. Each non-neutral signal enters at the next candle open and exits at that candle's close, preventing look-ahead into the execution candle. The buy-and-hold and SMA baselines use the declared fee/slippage assumptions.

## Validation

- `ruff check --no-cache .`
- `ruff format --check .`
- `pyright` — 0 errors
- `pytest` — 42 passed
- Editable package build/install verified as `bybit-predict 4.1.0a0`

Closes #25.