### PR TITLE
release: prepare v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Bybit-Predict are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project follows [Semantic Versioning](https://semver.org/).
 
-## [4.1.0] - In development
+## [4.1.0] - 2026-08-09
 
 ### Added
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -5,7 +5,7 @@
 
 **以 Bybit V5 公開市場資料為基礎的規則式加密貨幣市場分析、訊號產生與 Discord 整合工具。**
 
-> **目前正式版本：v4.0.0。**這個 major release 在保留 repo、issues、外部貢獻、forks 與 Git history 的前提下完成現代化重構；前一個 legacy release 為 v3.1。
+> **目前正式版本：v4.1.0。**此版本在 v4 的現代化 package 架構上加入可重現的歷史 backtesting，同時保留 repo、issues、外部貢獻、forks 與 Git history；前一個 legacy release 為 v3.1。
 
 [English](README.md)
 
@@ -28,7 +28,7 @@ Bybit-Predict 從 Bybit 取得 OHLCV K 線，產生供參考的市場訊號與�
 - 提供 CLI，以及可選用、非阻塞的 Discord slash command。
 - 透過 Bybit instrument metadata 驗證有效交易對，不再 hard-code 幣種清單。
 - 具備測試、Ruff、Pyright、GitHub Actions CI 與 Dependabot。
-- 提供可重現的歷史 backtesting：可保存 CSV 輸入、明確列出假設、計算績效指標，並與兩個簡單 baseline 比較（v4.1.0 開發中）。
+- 提供可重現的歷史 backtesting：可保存 CSV 輸入、明確列出假設、計算績效指標，並與兩個簡單 baseline 比較。
 
 ## 系統需求
 
@@ -89,7 +89,7 @@ Reference levels:
 
 ### 歷史 Backtest
 
-v4.1.0 開發分支加入可重現的 `backtest` command：策略只會看到先前的固定已收線
+v4.1.0 加入可重現的 `backtest` command：策略只會看到先前的固定已收線
 K 線 window；非 neutral 訊號在下一根 K 線開盤模擬進場、同一根收盤模擬出場。輸出會
 連同假設、績效指標和 baseline 一起顯示，不是交易建議。
 
@@ -212,7 +212,7 @@ PR 會在 Python 3.11、3.12 與 3.13 執行上述檢查。請參閱
 ## Roadmap
 
 - **v4.0.0：**package 架構、公開 Bybit V5 client、stateless legacy strategy、CLI、Discord slash command、設定、品質 gate 與文件。
-- **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)，開發中）。
+- **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）。
 - **後續：**可在同一 strategy contract 下加入更多策略；ML 是未來可能方向，並非現有功能。
 
 ## 貢獻與歷史

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 **Rule-based cryptocurrency market analysis, signal generation, and Discord
 integration powered by public Bybit V5 market data.**
 
-> **Current release: v4.0.0.** This major release modernizes the project
-> without discarding its repository, issues, merged contributions, or Git
-> history. The latest legacy release was v3.1.
+> **Current release: v4.1.0.** This release adds reproducible historical
+> backtesting to v4's modern package architecture without discarding the
+> repository, issues, merged contributions, or Git history. The latest legacy
+> release was v3.1.
 
 [繁體中文](README-zh.md)
 
@@ -38,8 +39,7 @@ outcome.
   coin list.
 - Tests, Ruff, Pyright, GitHub Actions CI, and Dependabot.
 - Deterministic historical backtesting with saved CSV inputs, explicit
-  assumptions, performance metrics, and two simple baselines (in development
-  for the v4.1.0 release).
+  assumptions, performance metrics, and two simple baselines.
 
 ## Requirements
 
@@ -101,10 +101,10 @@ BTCUSDT`.
 
 ### Backtest a historical range
 
-The v4.1.0 development branch adds a reproducible `backtest` command. It
-signals from a trailing closed-candle window, executes non-neutral signals at
-the next candle open, and exits at that candle close. The command prints its
-assumptions with metrics and baselines; it does not make a trading claim.
+v4.1.0 adds a reproducible `backtest` command. It signals from a trailing
+closed-candle window, executes non-neutral signals at the next candle open,
+and exits at that candle close. The command prints its assumptions with metrics
+and baselines; it does not make a trading claim.
 
 ```bash
 bybit-predict backtest BTCUSDT \
@@ -239,7 +239,7 @@ Pull requests run these checks on Python 3.11, 3.12, and 3.13. See
 - **v4.0.0:** package architecture, public Bybit V5 client, stateless legacy
   strategy, CLI, Discord slash command, configuration, quality gates, and
   documentation.
-- **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25), in development).
+- **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)).
 - **Later:** additional strategies may implement the same strategy contract;
   ML is a future option, not an implied feature.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.1.0a0"
+version = "4.1.0"
 description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.1.0a0"
+__version__ = "4.1.0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,4 +11,4 @@ def test_runtime_version_matches_package_metadata() -> None:
     with (project_root / "pyproject.toml").open("rb") as file:
         metadata = tomllib.load(file)
 
-    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.0a0"
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.0"


### PR DESCRIPTION
## Summary

Prepares the already-merged backtesting work for the formal **v4.1.0** release.

- Promotes package metadata from `4.1.0a0` to `4.1.0`.
- Updates the runtime/metadata version regression test.
- Dates the v4.1.0 changelog entry as 2026-08-09.
- Updates English and Traditional Chinese README files to identify v4.1.0 as the current release and remove development wording.

## Validation

- Editable package build/install verified as `bybit-predict 4.1.0`
- `ruff check --no-cache .`
- `ruff format --check .`
- `pyright` — 0 errors
- `pytest` — 42 passed

After merge: verify main CI, create annotated tag `v4.1.0` at the merge commit, then publish the GitHub Release.