### PR TITLE
chore: prepare v4.1.1 PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,40 @@ jobs:
       - run: ruff format --check .
       - run: pyright
       - run: pytest
+
+  package:
+    name: Build package distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e ".[dev]"
+      - run: python -m build
+      - run: python -m twine check --strict dist/*
+      - name: Verify distribution contents
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+          import zipfile
+
+          dist = Path("dist")
+          wheel = next(dist.glob("*.whl"))
+          sdist = next(dist.glob("*.tar.gz"))
+          with zipfile.ZipFile(wheel) as archive:
+              assert any(name.endswith("/LICENSE") for name in archive.namelist())
+          with tarfile.open(sdist) as archive:
+              assert any(member.name.endswith("/LICENSE") for member in archive.getmembers())
+          PY
+      - name: Smoke-test the wheel without source checkout imports
+        run: |
+          PACKAGE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          python -m venv .package-test-venv
+          .package-test-venv/bin/python -m pip install --no-deps dist/*.whl
+          .package-test-venv/bin/python -c "from importlib.metadata import version; assert version('bybit-predict') == '${PACKAGE_VERSION}'"
+          .package-test-venv/bin/bybit-predict --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and validate distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Verify the tag is on main and matches the package version
+        shell: python
+        run: |
+          import os
+          import pathlib
+          import subprocess
+          import tomllib
+
+          subprocess.run(["git", "fetch", "origin", "main"], check=True)
+          subprocess.run(["git", "merge-base", "--is-ancestor", "HEAD", "origin/main"], check=True)
+          version = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          if tag != f"v{version}":
+              raise SystemExit(f"tag {tag!r} does not match package version {version!r}")
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Validate package metadata and README rendering
+        run: python -m twine check --strict dist/*
+      - name: Verify distribution contents
+        shell: python
+        run: |
+          from pathlib import Path
+          import tarfile
+          import zipfile
+
+          dist = Path("dist")
+          wheel = next(dist.glob("*.whl"))
+          sdist = next(dist.glob("*.tar.gz"))
+          with zipfile.ZipFile(wheel) as archive:
+              assert any(name.endswith("/LICENSE") for name in archive.namelist())
+          with tarfile.open(sdist) as archive:
+              assert any(member.name.endswith("/LICENSE") for member in archive.getmembers())
+      - name: Smoke-test the wheel without source checkout imports
+        run: |
+          python -m venv .package-test-venv
+          .package-test-venv/bin/python -m pip install --no-deps dist/*.whl
+          .package-test-venv/bin/python -c "from importlib.metadata import version; assert version('bybit-predict') == '${GITHUB_REF_NAME#v}'"
+          .package-test-venv/bin/bybit-predict --help
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/bybit-predict/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-github:
+    name: Create GitHub Release
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" dist/* --repo "${{ github.repository }}" --generate-notes --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ __pycache__/
 htmlcov/
 .ruff_cache/
 .pyright/
+build/
+dist/
+.package-test-venv/
 
 # Local data and editor files
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Bybit-Predict are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project follows [Semantic Versioning](https://semver.org/).
 
+## [4.1.1] - In development
+
+### Added
+
+- PyPI distribution metadata, package-artifact verification, and a Trusted
+  Publishing workflow for future releases.
+
+### Changed
+
+- Installation documentation now prioritizes PyPI and pipx usage after the
+  first PyPI release.
+
 ## [4.1.0] - 2026-08-09
 
 ### Added

--- a/README-zh.md
+++ b/README-zh.md
@@ -40,6 +40,28 @@ Bybit-Predict 從 Bybit 取得 OHLCV K 線，產生供參考的市場訊號與�
 
 ## 安裝
 
+### 從 PyPI 安裝
+
+從 v4.1.1 開始會發布至 PyPI。該版本發布後，可安裝 CLI 與標準 Bybit V5 dependency：
+
+```bash
+python -m pip install bybit-predict
+```
+
+需要 Discord 介面時，再安裝 optional extra：
+
+```bash
+python -m pip install "bybit-predict[discord]"
+```
+
+若要隔離安裝 command-line tool，可使用 [pipx](https://pipx.pypa.io/)：
+
+```bash
+pipx install bybit-predict
+```
+
+### 從原始碼安裝
+
 ```bash
 git clone https://github.com/KageRyo/Bybit-Predict.git
 cd Bybit-Predict
@@ -209,10 +231,19 @@ PR 會在 Python 3.11、3.12 與 3.13 執行上述檢查。請參閱
 [CONTRIBUTING.md](CONTRIBUTING.md)，其中包含開發設定與必須遵守的
 `feature/<issue>-<description>` branch 命名規範。
 
+## 發布
+
+推送最終 release tag 時會建立 sdist 與 universal wheel、先驗證 artifact、經由 PyPI
+Trusted Publishing 發布，最後建立包含相同 artifacts 的 GitHub Release。維護者可閱讀
+[PyPI publishing](docs/pypi-publishing.md) 了解一次性的設定與 release 程序；repo 與
+GitHub Actions secrets 都不保存長效 PyPI API token。
+
 ## Roadmap
 
 - **v4.0.0：**package 架構、公開 Bybit V5 client、stateless legacy strategy、CLI、Discord slash command、設定、品質 gate 與文件。
 - **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）。
+- **v4.1.1：**PyPI distribution、Trusted Publishing 與 package-release automation
+  （[#37](https://github.com/KageRyo/Bybit-Predict/issues/37)，開發中）。
 - **後續：**可在同一 strategy contract 下加入更多策略；ML 是未來可能方向，並非現有功能。
 
 ## 貢獻與歷史

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ analysis. The optional Discord interface needs only a Discord bot token.
 
 ## Install
 
+### From PyPI
+
+PyPI publishing begins with v4.1.1. After that release, install the CLI and its
+standard Bybit V5 dependency with:
+
+```bash
+python -m pip install bybit-predict
+```
+
+Install the optional Discord interface when you need it:
+
+```bash
+python -m pip install "bybit-predict[discord]"
+```
+
+For an isolated command-line installation, use [pipx](https://pipx.pypa.io/):
+
+```bash
+pipx install bybit-predict
+```
+
+### From source
+
 ```bash
 git clone https://github.com/KageRyo/Bybit-Predict.git
 cd Bybit-Predict
@@ -60,7 +83,7 @@ python -m pip install --upgrade pip
 python -m pip install .
 ```
 
-For contributors, install development tools and the Discord extra:
+For contributors, install development and optional Discord dependencies:
 
 ```bash
 python -m pip install -e ".[dev]"
@@ -234,12 +257,23 @@ Pull requests run these checks on Python 3.11, 3.12, and 3.13. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and the required
 `feature/<issue>-<description>` branch convention.
 
+## Publishing
+
+Pushing a final release tag builds an sdist and universal wheel, validates them,
+publishes through PyPI Trusted Publishing, then creates a GitHub Release with
+the same artifacts. See
+[PyPI publishing](docs/pypi-publishing.md) for the maintainer-only setup and
+release procedure. No long-lived PyPI API token is stored in this repository or
+its GitHub Actions secrets.
+
 ## Roadmap
 
 - **v4.0.0:** package architecture, public Bybit V5 client, stateless legacy
   strategy, CLI, Discord slash command, configuration, quality gates, and
   documentation.
 - **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)).
+- **v4.1.1:** PyPI distribution, Trusted Publishing, and package-release
+  automation ([#37](https://github.com/KageRyo/Bybit-Predict/issues/37), in development).
 - **Later:** additional strategies may implement the same strategy contract;
   ML is a future option, not an implied feature.
 

--- a/docs/pypi-publishing.md
+++ b/docs/pypi-publishing.md
@@ -1,0 +1,57 @@
+# PyPI publishing
+
+Bybit-Predict v4.1.1 introduces distribution validation and automated PyPI
+publishing. The workflow builds both an sdist and a universal wheel from a
+release tag, validates their metadata and rendered README, verifies the GPL
+license is packaged, and smoke-tests the installed wheel's console script.
+
+It follows this project's HalfRand release pattern: a final SemVer tag builds
+and validates the artifacts, publishes them through
+[PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/), then
+creates a GitHub Release with those exact artifacts attached. The publish job
+receives job-scoped `id-token: write` permission and exchanges GitHub Actions'
+OIDC identity for a short-lived PyPI credential; no long-lived `PYPI_TOKEN` is
+used.
+
+## One-time maintainer setup
+
+These steps require a verified PyPI account with permission to create a
+project. They cannot be completed from this repository alone.
+
+1. In GitHub repository settings, create a protected environment named `release`
+   and require the release maintainer as an approver. The workflow separately
+   verifies that every release tag is reachable from `main`.
+2. In PyPI, open **Account settings → Publishing → Add a new pending
+   publisher**, select GitHub, and enter:
+
+   | Setting | Value |
+   | --- | --- |
+   | PyPI project name | `bybit-predict` |
+   | Owner | `KageRyo` |
+   | Repository | `Bybit-Predict` |
+   | Workflow filename | `release.yml` |
+   | Environment name | `release` |
+
+A pending publisher does not reserve a PyPI project name. Publish promptly
+after configuring it; otherwise another account may claim the name first.
+
+## Release procedure
+
+1. Merge a release-preparation PR that changes the package version from its
+   alpha form (for example `4.1.1a0`) to the final version (`4.1.1`) and dates
+   the changelog entry. Confirm main CI is green.
+2. Create and push the annotated release tag (for example `v4.1.1`) at that
+   verified main commit. The publishing workflow rejects an untagged ref, a tag
+   that is not reachable from `main`, or a tag whose version differs from
+   `pyproject.toml`.
+3. Push the tag. The `release.yml` workflow verifies the tag is reachable from
+   `main` and matches `pyproject.toml`, builds and validates the distributions,
+   waits for the protected `release` environment approval, then publishes to
+   PyPI. Only after that succeeds does it create the GitHub Release and attach
+   the exact wheel and sdist.
+4. Verify `python -m pip install bybit-predict==4.1.1` from a fresh virtual
+   environment and run `bybit-predict --help`.
+
+Do not add PyPI API tokens to GitHub secrets. If a release must be stopped,
+stop the GitHub deployment or revoke the PyPI Trusted Publisher rather than
+introducing a credential-based bypass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.1.0"
+version = "4.1.1a0"
 description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "GPL-2.0-or-later" }
+license = "GPL-2.0-or-later"
+license-files = ["LICENSE"]
 authors = [
   { name = "CodeRyo Studio" },
   { name = "Chien-Hsun Chang" },
@@ -32,10 +33,12 @@ discord = [
   "discord.py>=2.4,<3",
 ]
 dev = [
+  "build>=1.2,<2",
   "discord.py>=2.4,<3",
   "pytest>=8.3,<10",
   "pytest-cov>=5,<8",
   "ruff>=0.8,<1",
+  "twine>=6,<7",
   "pyright>=1.1.390,<2",
 ]
 
@@ -44,7 +47,10 @@ bybit-predict = "bybit_predict.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/KageRyo/Bybit-Predict"
+Repository = "https://github.com/KageRyo/Bybit-Predict"
+Documentation = "https://github.com/KageRyo/Bybit-Predict#readme"
 Issues = "https://github.com/KageRyo/Bybit-Predict/issues"
+Changelog = "https://github.com/KageRyo/Bybit-Predict/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/bybit_predict"]

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.1.0"
+__version__ = "4.1.1a0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,4 +11,4 @@ def test_runtime_version_matches_package_metadata() -> None:
     with (project_root / "pyproject.toml").open("rb") as file:
         metadata = tomllib.load(file)
 
-    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.0"
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.1a0"


### PR DESCRIPTION
## Summary

Prepares Bybit-Predict v4.1.1 for its first PyPI distribution, following the established HalfRand release pattern:

`vX.Y.Z` tag → build and validate artifacts → PyPI Trusted Publishing → GitHub Release with the exact artifacts.

- Adds complete PyPI metadata, explicit GPL license-file inclusion, and a `4.1.1a0` development version.
- Adds a CI package job that builds, runs strict Twine validation, verifies LICENSE inclusion, and smoke-tests the installed wheel/CLI.
- Adds a tag-only release workflow with tag/version and main-ancestry gates; it publishes through the protected `release` environment using OIDC, then creates the GitHub Release.
- Documents pip, optional Discord extra, pipx installation, trusted-publisher setup, and the release procedure in English and Traditional Chinese.
- Adds the repository's protected `release` environment, requiring KageRyo approval before publishing.

No strategy, market-data, signal, or backtesting behavior changes.

## Validation

- `ruff check --no-cache .`
- `ruff format --check .`
- `pyright`
- `pytest` — 42 passed
- `python -m build`
- `python -m twine check --strict` on wheel and sdist
- Fresh virtualenv wheel install, metadata / GPL license checks, and `bybit-predict --help`

## Publishing configuration

PyPI's pending Trusted Publisher has been configured for project `bybit-predict`, owner `KageRyo`, repository `Bybit-Predict`, workflow `release.yml`, and environment `release`. No long-lived PyPI token is used.

Closes #37