### PR TITLE
release: prepare v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Bybit-Predict are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project follows [Semantic Versioning](https://semver.org/).
 
-## [4.1.1] - In development
+## [4.1.1] - 2026-08-09
 
 ### Added
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -42,7 +42,7 @@ Bybit-Predict 從 Bybit 取得 OHLCV K 線，產生供參考的市場訊號與�
 
 ### 從 PyPI 安裝
 
-從 v4.1.1 開始會發布至 PyPI。該版本發布後，可安裝 CLI 與標準 Bybit V5 dependency：
+可透過 PyPI 安裝 CLI 與標準 Bybit V5 dependency：
 
 ```bash
 python -m pip install bybit-predict
@@ -243,7 +243,7 @@ GitHub Actions secrets 都不保存長效 PyPI API token。
 - **v4.0.0：**package 架構、公開 Bybit V5 client、stateless legacy strategy、CLI、Discord slash command、設定、品質 gate 與文件。
 - **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）。
 - **v4.1.1：**PyPI distribution、Trusted Publishing 與 package-release automation
-  （[#37](https://github.com/KageRyo/Bybit-Predict/issues/37)，開發中）。
+  （[#37](https://github.com/KageRyo/Bybit-Predict/issues/37)）。
 - **後續：**可在同一 strategy contract 下加入更多策略；ML 是未來可能方向，並非現有功能。
 
 ## 貢獻與歷史

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ analysis. The optional Discord interface needs only a Discord bot token.
 
 ### From PyPI
 
-PyPI publishing begins with v4.1.1. After that release, install the CLI and its
-standard Bybit V5 dependency with:
+Install the CLI and its standard Bybit V5 dependency with:
 
 ```bash
 python -m pip install bybit-predict
@@ -273,7 +272,7 @@ its GitHub Actions secrets.
   documentation.
 - **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)).
 - **v4.1.1:** PyPI distribution, Trusted Publishing, and package-release
-  automation ([#37](https://github.com/KageRyo/Bybit-Predict/issues/37), in development).
+  automation ([#37](https://github.com/KageRyo/Bybit-Predict/issues/37)).
 - **Later:** additional strategies may implement the same strategy contract;
   ML is a future option, not an implied feature.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.1.1a0"
+version = "4.1.1"
 description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.1.1a0"
+__version__ = "4.1.1"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,4 +11,4 @@ def test_runtime_version_matches_package_metadata() -> None:
     with (project_root / "pyproject.toml").open("rb") as file:
         metadata = tomllib.load(file)
 
-    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.1a0"
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.1"


### PR DESCRIPTION
## Summary

Finalizes the first PyPI release as `v4.1.1`.

- Promotes package and runtime version from `4.1.1a0` to `4.1.1`.
- Dates the v4.1.1 changelog entry.
- Updates English and Traditional Chinese README text so PyPI is the current installation path and v4.1.1 is no longer listed as in development.

No dependency, workflow, strategy, signal, market-data, or backtesting behavior changes.

## Release-artifact validation

- `ruff check --no-cache .`
- `ruff format --check .`
- `pyright`
- `pytest` — 42 passed
- Built `bybit_predict-4.1.1.tar.gz` and `bybit_predict-4.1.1-py3-none-any.whl`
- `twine check --strict` passed for both artifacts
- Both artifacts include the GPL LICENSE
- Fresh-environment wheel install reports `4.1.1` and `bybit-predict --help` succeeds

After this PR merges, push the annotated `v4.1.1` tag from its merge commit. The release workflow will validate the tag, await the `release` environment approval, publish to PyPI via Trusted Publishing, and then create the GitHub Release with the exact artifacts.