### PR TITLE
docs: align release metadata for v4.1.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,5 @@
 
 - [ ] Branch follows `feature/<issue>-<description>`.
 - [ ] No credentials, `.env` files, or generated market data were committed.
-- [ ] English and Traditional Chinese documentation are aligned when relevant.
+- [ ] English and 正體中文 documentation are aligned when relevant.
 - [ ] Outputs remain clearly labelled as informational, not financial advice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Bybit-Predict are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project follows [Semantic Versioning](https://semver.org/).
 
+## [4.1.2] - 2026-08-09
+
+### Fixed
+
+- Corrected released-version labels in the English and 正體中文 README files.
+- Replaced stale future-release references in release and legacy migration
+  documentation.
+
+### Changed
+
+- PyPI metadata now describes the reproducible backtesting toolkit and includes
+  matching discovery keywords.
+- Labelled the Chinese documentation as 正體中文.
+- CLI help now names both market analysis and reproducible backtesting.
+
 ## [4.1.1] - 2026-08-09
 
 ### Added

--- a/README-zh.md
+++ b/README-zh.md
@@ -5,7 +5,9 @@
 
 **以 Bybit V5 公開市場資料為基礎的規則式加密貨幣市場分析、訊號產生與 Discord 整合工具。**
 
-> **目前正式版本：v4.1.0。**此版本在 v4 的現代化 package 架構上加入可重現的歷史 backtesting，同時保留 repo、issues、外部貢獻、forks 與 Git history；前一個 legacy release 為 v3.1。
+> **目前正式版本：v4.1.2。**此文件與 PyPI metadata 修補版本反映 v4.1.1 的 PyPI
+> 發行與 v4.1.0 的可重現歷史回測；專案仍刻意保留 repo、issues、已 merge 的貢獻、forks
+> 與 Git history。前一個 legacy release 為 v3.1。
 
 [English](README.md)
 
@@ -238,12 +240,13 @@ Trusted Publishing 發布，最後建立包含相同 artifacts 的 GitHub Releas
 [PyPI publishing](docs/pypi-publishing.md) 了解一次性的設定與 release 程序；repo 與
 GitHub Actions secrets 都不保存長效 PyPI API token。
 
-## Roadmap
+## 發行歷史與規劃
 
 - **v4.0.0：**package 架構、公開 Bybit V5 client、stateless legacy strategy、CLI、Discord slash command、設定、品質 gate 與文件。
 - **v4.1.0：**reproducible backtesting 與評估（[#25](https://github.com/KageRyo/Bybit-Predict/issues/25)）。
 - **v4.1.1：**PyPI distribution、Trusted Publishing 與 package-release automation
   （[#37](https://github.com/KageRyo/Bybit-Predict/issues/37)）。
+- **v4.1.2：**文件與 PyPI metadata 修正（[#40](https://github.com/KageRyo/Bybit-Predict/issues/40)）。
 - **後續：**可在同一 strategy contract 下加入更多策略；ML 是未來可能方向，並非現有功能。
 
 ## 貢獻與歷史

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 **Rule-based cryptocurrency market analysis, signal generation, and Discord
 integration powered by public Bybit V5 market data.**
 
-> **Current release: v4.1.0.** This release adds reproducible historical
-> backtesting to v4's modern package architecture without discarding the
-> repository, issues, merged contributions, or Git history. The latest legacy
-> release was v3.1.
+> **Current release: v4.1.2.** This documentation and PyPI metadata patch
+> reflects the PyPI distribution introduced in v4.1.1 and the reproducible
+> historical backtesting introduced in v4.1.0. The repository, issues, merged
+> contributions, and Git history remain intentionally preserved; the latest
+> legacy release was v3.1.
 
-[繁體中文](README-zh.md)
+[正體中文](README-zh.md)
 
 ## What Bybit-Predict is — and is not
 
@@ -265,7 +266,7 @@ the same artifacts. See
 release procedure. No long-lived PyPI API token is stored in this repository or
 its GitHub Actions secrets.
 
-## Roadmap
+## Release history and roadmap
 
 - **v4.0.0:** package architecture, public Bybit V5 client, stateless legacy
   strategy, CLI, Discord slash command, configuration, quality gates, and
@@ -273,6 +274,8 @@ its GitHub Actions secrets.
 - **v4.1.0:** reproducible backtesting and evaluation ([#25](https://github.com/KageRyo/Bybit-Predict/issues/25)).
 - **v4.1.1:** PyPI distribution, Trusted Publishing, and package-release
   automation ([#37](https://github.com/KageRyo/Bybit-Predict/issues/37)).
+- **v4.1.2:** documentation and PyPI metadata corrections
+  ([#40](https://github.com/KageRyo/Bybit-Predict/issues/40)).
 - **Later:** additional strategies may implement the same strategy contract;
   ML is a future option, not an implied feature.
 

--- a/docs/legacy-strategy-changes.md
+++ b/docs/legacy-strategy-changes.md
@@ -8,7 +8,7 @@ and time references. It is not an ML model.
 Version 4 is not a byte-for-byte replay of the v3 implementation. The changes
 below are intentional, documented bug fixes and are covered by regression
 tests. They make the strategy's output suitable for deterministic evaluation
-and the planned v4.1.0 backtesting work.
+and the reproducible backtesting introduced in v4.1.0.
 
 | Area | v3 behavior | v4 behavior | Reason |
 | --- | --- | --- | --- |

--- a/docs/pypi-publishing.md
+++ b/docs/pypi-publishing.md
@@ -1,9 +1,9 @@
 # PyPI publishing
 
-Bybit-Predict v4.1.1 introduces distribution validation and automated PyPI
-publishing. The workflow builds both an sdist and a universal wheel from a
-release tag, validates their metadata and rendered README, verifies the GPL
-license is packaged, and smoke-tests the installed wheel's console script.
+Bybit-Predict is distributed through PyPI. The workflow builds both an sdist
+and a universal wheel from each release tag, validates their metadata and
+rendered README, verifies the GPL license is packaged, and smoke-tests the
+installed wheel's console script.
 
 It follows this project's HalfRand release pattern: a final SemVer tag builds
 and validates the artifacts, publishes them through
@@ -15,8 +15,8 @@ used.
 
 ## One-time maintainer setup
 
-These steps require a verified PyPI account with permission to create a
-project. They cannot be completed from this repository alone.
+The first PyPI publication requires a verified PyPI account with permission to
+create a project. It cannot be completed from this repository alone.
 
 1. In GitHub repository settings, create a protected environment named `release`
    and require the release maintainer as an approver. The workflow separately
@@ -32,24 +32,25 @@ project. They cannot be completed from this repository alone.
    | Workflow filename | `release.yml` |
    | Environment name | `release` |
 
-A pending publisher does not reserve a PyPI project name. Publish promptly
-after configuring it; otherwise another account may claim the name first.
+Before the first publication, a pending publisher does not reserve a PyPI
+project name. Publish promptly after configuring it; otherwise another account
+may claim the name first.
 
 ## Release procedure
 
-1. Merge a release-preparation PR that changes the package version from its
-   alpha form (for example `4.1.1a0`) to the final version (`4.1.1`) and dates
-   the changelog entry. Confirm main CI is green.
-2. Create and push the annotated release tag (for example `v4.1.1`) at that
-   verified main commit. The publishing workflow rejects an untagged ref, a tag
-   that is not reachable from `main`, or a tag whose version differs from
-   `pyproject.toml`.
+1. Merge a release-preparation PR that sets the package and runtime versions to
+   the immutable final PEP 440 value (for example `4.1.2`), updates the version
+   test, and dates the changelog entry. Confirm main CI is green.
+2. Create and push the annotated release tag (`v<version>`, for example
+   `v4.1.2`) at that verified main commit. The publishing workflow rejects an
+   untagged ref, a tag that is not reachable from `main`, or a tag whose version
+   differs from `pyproject.toml`.
 3. Push the tag. The `release.yml` workflow verifies the tag is reachable from
    `main` and matches `pyproject.toml`, builds and validates the distributions,
    waits for the protected `release` environment approval, then publishes to
    PyPI. Only after that succeeds does it create the GitHub Release and attach
    the exact wheel and sdist.
-4. Verify `python -m pip install bybit-predict==4.1.1` from a fresh virtual
+4. Verify `python -m pip install bybit-predict==<version>` from a fresh virtual
    environment and run `bybit-predict --help`.
 
 Do not add PyPI API tokens to GitHub secrets. If a release must be stopped,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bybit-predict"
-version = "4.1.1"
-description = "Rule-based cryptocurrency market signal analysis using Bybit V5 market data."
+version = "4.1.2"
+description = "Rule-based cryptocurrency market analysis and reproducible backtesting using Bybit V5 market data."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "GPL-2.0-or-later"
@@ -14,7 +14,15 @@ authors = [
   { name = "CodeRyo Studio" },
   { name = "Chien-Hsun Chang" },
 ]
-keywords = ["bybit", "cryptocurrency", "market-analysis", "signals", "discord"]
+keywords = [
+  "backtesting",
+  "bybit",
+  "cryptocurrency",
+  "discord",
+  "market-analysis",
+  "python-cli",
+  "signals",
+]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",

--- a/src/bybit_predict/__init__.py
+++ b/src/bybit_predict/__init__.py
@@ -5,4 +5,4 @@
 from bybit_predict.models import Candle, PredictionResult, SignalTrend
 
 __all__ = ["Candle", "PredictionResult", "SignalTrend"]
-__version__ = "4.1.1"
+__version__ = "4.1.2"

--- a/src/bybit_predict/cli.py
+++ b/src/bybit_predict/cli.py
@@ -29,7 +29,10 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser without starting any network client."""
     parser = argparse.ArgumentParser(
         prog="bybit-predict",
-        description="Rule-based cryptocurrency market analysis using public Bybit V5 data.",
+        description=(
+            "Rule-based cryptocurrency market analysis and reproducible backtesting "
+            "using public Bybit V5 data."
+        ),
     )
     subcommands = parser.add_subparsers(dest="command", required=True)
     analyze = subcommands.add_parser("analyze", help="Analyze a Bybit trading symbol")

--- a/tests/unit/test_cli_and_presentation.py
+++ b/tests/unit/test_cli_and_presentation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from pathlib import Path
 
-from bybit_predict.cli import main
+from bybit_predict.cli import build_parser, main
 from bybit_predict.models import Candle
 from bybit_predict.presentation import format_result_text
 from bybit_predict.services.predictor import PredictionService
@@ -23,6 +23,12 @@ def test_cli_prints_shared_service_result(candles: tuple) -> None:
     )
 
     assert status == 0
+
+
+def test_cli_description_matches_the_analysis_and_backtesting_positioning() -> None:
+    description = build_parser().description
+    assert description is not None
+    assert "reproducible backtesting" in description
 
 
 def test_cli_rejects_limits_the_legacy_strategy_cannot_analyze(capsys: object) -> None:

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,4 +11,4 @@ def test_runtime_version_matches_package_metadata() -> None:
     with (project_root / "pyproject.toml").open("rb") as file:
         metadata = tomllib.load(file)
 
-    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.1"
+    assert bybit_predict.__version__ == metadata["project"]["version"] == "4.1.2"


### PR DESCRIPTION
## Summary

Releases v4.1.2 as a documentation and PyPI metadata consistency patch.

- Corrects the public release banners from v4.1.0 to v4.1.2.
- Labels the Chinese documentation as 正體中文.
- Generalizes PyPI release instructions and corrects the legacy migration reference.
- Aligns PyPI Summary/keywords and CLI help with the analysis and reproducible-backtesting toolkit positioning.
- Updates version metadata, tests, and changelog.

No market-data, strategy, signal, backtesting, dependency, or API behavior changes.

## Validation

- `ruff check --no-cache .`
- `ruff format --check .`
- `pyright`
- `pytest` — 43 passed
- Built `bybit_predict-4.1.2.tar.gz` and `bybit_predict-4.1.2-py3-none-any.whl`
- `twine check --strict` passed
- Fresh-environment install verified version, PyPI Summary, GPL license metadata, and the CLI help description

Closes #40