### PR TITLE
chore: restore the official GPL v2 license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -302,7 +302,7 @@ convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    <one line to give the program's name and the year of the name of the author>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

Preserve the project-specific licensing preamble and replace the GNU GPL v2 section with the official unmodified text.

## Validation

- The change is limited to `LICENSE`.
- The resulting license text was read back from the branch and verified.
- No application code or behavior is changed.

Closes #45